### PR TITLE
feat(shops): add shop listing and details pages

### DIFF
--- a/frontend/src/components/layouts/navigation.js
+++ b/frontend/src/components/layouts/navigation.js
@@ -2,7 +2,7 @@ import { FaHome, FaStore, FaBlog, FaPhone, FaInfo } from "react-icons/fa";
 
 export const navigation = [
   { id: 1, title: "Home", path: "/", icon: <FaHome /> },
-  { id: 2, title: "Shop", path: "/shop", icon: <FaStore /> },
+  { id: 2, title: "Shop", path: "/shops", icon: <FaStore /> },
   { id: 3, title: "Blog", path: "/blog", icon: <FaBlog /> },
   { id: 4, title: "About Us", path: "/about", icon: <FaInfo /> },
   { id: 5, title: "Contact Us", path: "/contact", icon: <FaPhone /> },

--- a/frontend/src/pages/ShopListPage.jsx
+++ b/frontend/src/pages/ShopListPage.jsx
@@ -1,0 +1,28 @@
+import { Link } from "react-router-dom";
+
+const ShopListPage = () => {
+  const mockShops = [
+    { id: "a", name: "Luna Store" },
+    { id: "b", name: "Galaxy Handmade" },
+    { id: "c", name: "BookNest" },
+  ];
+
+  return (
+    <div className="w-[85%] mx-auto py-12">
+      <h1 className="text-2xl font-bold mb-6">Popular Shops</h1>
+      <div className="grid grid-cols-2 sm:grid-cols-1 gap-6">
+        {mockShops.map((shop) => (
+          <Link
+            key={shop.id}
+            to={`/shops/${shop.id}`}
+            className="p-6 border rounded hover:bg-slate-50"
+          >
+            {shop.name}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ShopListPage;

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,6 +2,8 @@ import React from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import MainLayout from "../components/layouts/MainLayout";
 import Home from "../pages/Home";
+import ShopListPage from "../pages/ShopListPage";
+import ShopsDetails from "../pages/ShopDetails";
 
 const index = () => {
   return (
@@ -9,6 +11,8 @@ const index = () => {
       <Routes>
         <Route path="/" element={<MainLayout />}>
           <Route path="/" element={<Home />} />
+          <Route path="/shops" element={<ShopListPage />} />
+          <Route path="/shops/:shop-id" element={<ShopsDetails />} />
         </Route>
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
Introduce new pages for displaying a list of shops and individual shop details. Update navigation path to reflect the new shop routes. This change enables users to browse shops and view detailed information about each shop.

closes #37