### PR TITLE
feat(ProductDetails): add related products section and improve UI

### DIFF
--- a/frontend/src/components/products/ProductCard.jsx
+++ b/frontend/src/components/products/ProductCard.jsx
@@ -7,7 +7,7 @@ import Ratings from "../shared/Ratings";
 
 const ProductCard = () => {
   return (
-    <div className="border group transition-all duration-500 hover:shadow-md hover:mt-[-3px]">
+    <div className="border group transition-all duration-500 hover:-translate-y-1 hover:shadow-md">
       <div className="relative overflow-hidden">
         <div className="flex justify-center items-center absolute text-white size-[38px] rounded-full bg-red-500 font-semibold text-xs left-2 top-2">
           8%

--- a/frontend/src/pages/ProductDetails.jsx
+++ b/frontend/src/pages/ProductDetails.jsx
@@ -16,6 +16,7 @@ import {
 } from "react-icons/fa";
 import { cn } from "../utils/cn";
 import ProductReviews from "../components/products/ProductReviews";
+import ProductCard from "../components/products/ProductCard";
 
 let discount = 10;
 let stock = 10;
@@ -193,11 +194,14 @@ const ProductDetails = () => {
           <div className="flex flex-wrap">
             <div className="w-[72%] md-lg:w-full">
               <div className="pr-4 md-lg:pr-0">
-                <div className="grid grid-cols-2">
+                <div className="grid grid-cols-2 gap-2">
                   <button
                     className={cn(
-                      "py-1  px-5 hover:bg-[#059473]/40 hover:text-emerald-800 rounded-md outline-none",
-                      activeTab === "reviews" && "bg-[#059473] text-white"
+                      "py-1  px-5 hover:bg-[#059473]/40 hover:text-slate-700 rounded-md outline-none",
+                      {
+                        "bg-[#059473] text-white": activeTab === "reviews",
+                        "bg-slate-200 text-slate-700": activeTab !== "reviews",
+                      }
                     )}
                     onClick={() => setActiveTab("reviews")}
                   >
@@ -205,8 +209,12 @@ const ProductDetails = () => {
                   </button>
                   <button
                     className={cn(
-                      "py-1 hover:text-emerald-800 px-5 hover:bg-[#059473]/40 rounded-md outline-none",
-                      activeTab === "descriptions" && "bg-[#059473] text-white"
+                      "py-1 hover:text-slate-700 px-5 hover:bg-[#059473]/40 rounded-md outline-none",
+                      {
+                        "bg-[#059473] text-white": activeTab === "descriptions",
+                        "bg-slate-200 text-slate-700":
+                          activeTab !== "descriptions",
+                      }
                     )}
                     onClick={() => setActiveTab("descriptions")}
                   >
@@ -234,6 +242,18 @@ const ProductDetails = () => {
                     </>
                   )}
                 </div>
+              </div>
+            </div>
+            <div className="w-[28%] md-lg:w-full">
+              <div className="flex flex-col justify-center items-center">
+                <h2 className="text-base font-semibold text-slate-700 bg-slate-200 w-full text-center py-1 rounded-md mb-4">
+                  Related Products
+                </h2>
+                {[1, 2, 3, 4, 5, 6].map((_, i) => (
+                  <div className="w-[90%] mb-3">
+                    <ProductCard />
+                  </div>
+                ))}
               </div>
             </div>
           </div>


### PR DESCRIPTION
closes #46

- Added a "Related Products" section to the ProductDetails page, displaying multiple ProductCard components
- Improved button styling by adding conditional background and text colors based on active tab state
- Added a gap between grid items in the button section for better spacing
