### PR TITLE
feat(featured-product): add endpoint to fetch partitioned featured pr…

### DIFF
--- a/backend/controllers/featured-product.controller.ts
+++ b/backend/controllers/featured-product.controller.ts
@@ -1,3 +1,4 @@
+import { BadRequestError } from "@/errors";
 import ResponseModel from "@/models/response.model";
 import { FeaturedProductService } from "@/services/featured-product.service";
 import { NextFunction, Request, Response } from "express";
@@ -56,6 +57,34 @@ class FeaturedProductController {
         "Featured products fetched successfully.",
         result.products,
         result.pagination
+      ).send(res);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getPartitionedFeaturedProducts(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) {
+    try {
+      const { types } = req.query as { types?: string };
+
+      if (!types) {
+        return next(new BadRequestError("Missing types parameter"));
+      }
+
+      const typeArray = types.split(",").map((type) => type.trim());
+
+      const partitionedProducts =
+        await this.featureProductService.getPartitionedFeaturedProducts(
+          typeArray
+        );
+
+      ResponseModel.ok(
+        "Partitioned featured products fetched successfully.",
+        partitionedProducts
       ).send(res);
     } catch (error) {
       next(error);

--- a/backend/routes/featured-product.routes.ts
+++ b/backend/routes/featured-product.routes.ts
@@ -20,4 +20,11 @@ router.get(
   featuredProductController.getFeaturedProducts.bind(featuredProductController)
 );
 
+router.get(
+  "/featured/partitioned",
+  featuredProductController.getPartitionedFeaturedProducts.bind(
+    featuredProductController
+  )
+);
+
 export default router;

--- a/backend/services/featured-product.service.ts
+++ b/backend/services/featured-product.service.ts
@@ -1,6 +1,13 @@
 import FeaturedProductModel from "@/models/featured-product.model";
 import { sanitizeDocument } from "@/utils/mongoose.util";
 
+const sortMap: Record<string, any> = {
+  latest: { createdAt: -1 },
+  topRated: { ratings: -1 },
+  discount: { discount: -1 },
+  promotion: { displayOrder: 1 },
+};
+
 export class FeaturedProductService {
   async addFeaturedProduct(
     productId: string,
@@ -63,6 +70,39 @@ export class FeaturedProductService {
         totalPages: Math.ceil(totalItems / limit),
       },
     };
+  }
+
+  async getPartitionedFeaturedProducts(types: string[]) {
+    const partitionedResult: Record<string, any[]> = {};
+
+    for (const type of types) {
+      const sort = sortMap[type] || { createdAt: -1 };
+
+      const featuredProducts = await FeaturedProductModel.find({
+        featureType: { $in: [type] },
+      })
+        .sort(sort)
+        .limit(12)
+        .populate("productId", "name price images slug");
+
+      partitionedResult[type] = featuredProducts.map((item) => {
+        const product = item.productId as any;
+        return {
+          id: item._id,
+          productId: product._id,
+          featureType: item.featureType,
+          displayOrder: item.displayOrder,
+          product: {
+            name: product.name,
+            price: product.price,
+            thumbnailUrl: product.images?.[0] || "",
+            slug: product.slug,
+          },
+        };
+      });
+    }
+
+    return partitionedResult;
   }
 }
 


### PR DESCRIPTION
…oducts

This commit introduces a new endpoint `/featured/partitioned` that allows fetching featured products partitioned by their types. The endpoint accepts a `types` query parameter to specify the types of featured products to retrieve. The service layer has been updated to handle the partitioning and sorting logic based on the provided types.