### PR TITLE
feat(shop): add shop categories endpoint and integrate with frontend

### DIFF
--- a/backend/controllers/shop.controller.ts
+++ b/backend/controllers/shop.controller.ts
@@ -64,6 +64,21 @@ class ShopController {
       next(err);
     }
   }
+
+  async getShopCategories(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { shopId } = req.params;
+
+      const categories = await this.shopService.getCategoriesByShopId(shopId);
+
+      ResponseModel.ok(
+        "Shop categories fetched successfully.",
+        categories
+      ).send(res);
+    } catch (error) {
+      next(error);
+    }
+  }
 }
 
 export default ShopController;

--- a/backend/routes/shop.routes.ts
+++ b/backend/routes/shop.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import ShopController from "@/controllers/shop.controller";
+import shopService from "@/services/shop.service";
+
+const shopController = new ShopController(shopService);
+
+const router = Router();
+
+router.get(
+  "/:shopId/categories",
+  shopController.getShopCategories.bind(shopController)
+);
+
+export default router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -13,6 +13,7 @@ import adminRoutes from "@/routes/admin.routes";
 import sellerRoutes from "@/routes/seller.routes";
 import categoryRoutes from "@/routes/category.routes";
 import productRoutes from "@/routes/product.routes";
+import shopRoutes from "@/routes/shop.routes";
 
 dotenv.config();
 
@@ -33,6 +34,7 @@ app.use("/api/admin", adminRoutes);
 app.use("/api/seller", sellerRoutes);
 app.use("/api", categoryRoutes);
 app.use("/api", productRoutes);
+app.use("/api/shops", shopRoutes);
 
 app.use(errorMiddleware);
 

--- a/backend/services/shop.service.ts
+++ b/backend/services/shop.service.ts
@@ -1,10 +1,12 @@
-import Shop from "@/models/shop.model";
-import Seller from "@/models/seller.model";
+import ShopModel from "@/models/shop.model";
+import SellerModel from "@/models/seller.model";
+import ProductModel from "@/models/product.model";
 import { sanitizeDocument } from "@/utils/mongoose.util";
+import { NotFoundError } from "@/errors";
 
 class ShopService {
   async getShopBySellerId(sellerId: string) {
-    const shop = await Shop.findOne({ seller: sellerId });
+    const shop = await ShopModel.findOne({ seller: sellerId });
 
     if (!shop) return null;
 
@@ -12,16 +14,62 @@ class ShopService {
   }
 
   async createShop(sellerId: string, shopData: any) {
-    const existingShop = await Shop.findOne({ seller: sellerId });
+    const existingShop = await ShopModel.findOne({ seller: sellerId });
     if (existingShop) {
       throw new Error("This seller already has a shop.");
     }
 
-    const shop = await Shop.create({ seller: sellerId, ...shopData });
+    const shop = await ShopModel.create({ seller: sellerId, ...shopData });
 
-    await Seller.findByIdAndUpdate(sellerId, { shop: shop._id });
+    await SellerModel.findByIdAndUpdate(sellerId, { shop: shop._id });
 
     return sanitizeDocument(shop);
+  }
+
+  async getCategoriesByShopId(shopId: string) {
+    // 1. find sellerId by shopId
+    const shop = await ShopModel.findById(shopId);
+    if (!shop) {
+      throw new NotFoundError("Shop not found");
+    }
+
+    // 2. find all unique categories by sellerId
+    const categoryIds = await ProductModel.distinct("category", {
+      seller: shop.seller,
+    });
+
+    const results = await ProductModel.aggregate([
+      {
+        $match: { seller: shop.seller }, 
+      },
+      {
+        $group: {
+          _id: "$category",
+          count: { $sum: 1 },
+        },
+      },
+      {
+        $lookup: {
+          from: "categories", 
+          localField: "_id",
+          foreignField: "_id",
+          as: "categoryInfo",
+        },
+      },
+      {
+        $unwind: "$categoryInfo", 
+      },
+      {
+        $project: {
+          _id: 0,
+          categoryId: "$categoryInfo._id",
+          name: "$categoryInfo.name",
+          count: 1,
+        },
+      },
+    ]);
+
+    return results;
   }
 }
 

--- a/frontend/src/components/features/products/ProductGrid.jsx
+++ b/frontend/src/components/features/products/ProductGrid.jsx
@@ -2,9 +2,7 @@ import React from "react";
 import ProductCard from "./ProductCard";
 import { cn } from "@mern/utils";
 
-const ProductGrid = ({ className, productList }) => {
-  console.log(productList);
-
+const ProductGrid = ({ className, productList = [] }) => {
   return (
     <div
       className={cn(

--- a/frontend/src/pages/ShopDetails.jsx
+++ b/frontend/src/pages/ShopDetails.jsx
@@ -11,6 +11,8 @@ import ProductStack from "../components/features/products/ProductStack";
 import ProductGrid from "../components/features/products/ProductGrid";
 import ProductList from "../components/features/products/ProductList";
 import PageBanner from "../components/shared/PageBanner";
+import { useGetShopCategoriesQuery } from "../store/features/shopApi";
+import { useParams } from "react-router-dom";
 
 const dummyCategories = [
   "All Categories",
@@ -28,11 +30,15 @@ const dummyCategories = [
 const viewModes = ["grid", "list"];
 
 const Shops = () => {
+  const { shopId } = useParams();
+
   const [filter, setFilter] = useState(true);
   const [state, setState] = useState({ values: [10, 2000] });
   const [selectedRating, setSelectedRating] = useState(0);
   const [viewMode, setViewMode] = useState("grid");
   const { currentPage, setCurrentPage, perPage } = usePagination();
+
+  const { data: categories } = useGetShopCategoriesQuery(shopId);
 
   return (
     <div>
@@ -71,19 +77,25 @@ const Shops = () => {
                 <h2 className="text-3xl font-bold text-slate-600 mb-3">
                   Category
                 </h2>
-                <div className="py-2">
-                  {dummyCategories.map((category, index) => (
-                    <div
-                      key={index}
+                <ul className="py-2">
+                  <li className="flex justify-start items-center gap-2 py-1">
+                    <input type="checkbox" className="ml-2 text-slate-600" />
+                    <label className="text-sm font-semibold text-slate-600">
+                      All Categories
+                    </label>
+                  </li>
+                  {categories?.data?.map(({ name, categoryId, count }) => (
+                    <li
+                      key={categoryId}
                       className="flex justify-start items-center gap-2 py-1"
                     >
                       <input type="checkbox" className="ml-2 text-slate-600" />
                       <label className="text-sm font-semibold text-slate-600">
-                        {category}
+                        {name} ({count})
                       </label>
-                    </div>
+                    </li>
                   ))}
-                </div>
+                </ul>
               </div>
 
               <div className="py-2 flex flex-col gap-5">

--- a/frontend/src/store/features/shopApi.js
+++ b/frontend/src/store/features/shopApi.js
@@ -6,12 +6,8 @@ import axiosBaseQueryWithReauth from "../../api/axiosBaseQuery";
 export const shopApi = createApi({
   reducerPath: "shopApi",
   baseQuery: axiosBaseQueryWithReauth,
-  tagTypes: ["Shop"],
+  tagTypes: ["Shop", "ShopCategories"],
   endpoints: shopEndpoints,
 });
 
-export const {
-  useGetShopForCurrentSellerQuery,
-  useAddShopMutation,
-  useUpdateShopMutation,
-} = shopApi;
+export const { useGetShopCategoriesQuery } = shopApi;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -4,13 +4,15 @@ import logger from "redux-logger";
 import rootReducer from "./rootReducer";
 import { categoryApi } from "./features/categoryApi";
 import { featuredProductApi } from "./features/featuredProductApi";
+import { shopApi } from "./features/shopApi";
 
 const store = configureStore({
   reducer: rootReducer,
   middleware: (getDefaultMiddleware) => {
     const middlewares = getDefaultMiddleware().concat(
       categoryApi.middleware,
-      featuredProductApi.middleware
+      featuredProductApi.middleware,
+      shopApi.middleware
     );
 
     middlewares.concat(logger);

--- a/frontend/src/store/rootReducer.js
+++ b/frontend/src/store/rootReducer.js
@@ -1,9 +1,11 @@
 import { categoryApi } from "./features/categoryApi";
 import { featuredProductApi } from "./features/featuredProductApi";
+import { shopApi } from "./features/shopApi";
 
 const rootReducer = {
   [categoryApi.reducerPath]: categoryApi.reducer,
   [featuredProductApi.reducerPath]: featuredProductApi.reducer,
+  [shopApi.reducerPath]: shopApi.reducer,
 };
 
 export default rootReducer;

--- a/packages/apis/src/index.ts
+++ b/packages/apis/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./categoryEndpoints";
 export * from "./productEndpoints";
 export * from "./featuredProductEndpoints";
+export * from "./shopEndpoints";

--- a/packages/apis/src/shopEndpoints.ts
+++ b/packages/apis/src/shopEndpoints.ts
@@ -1,0 +1,37 @@
+export const shopEndpoints = (builder: any) => ({
+  getShopForCurrentSeller: builder.query({
+    query: () => ({
+      url: "/shop",
+      method: "GET",
+      isSeller: true,
+    }),
+    providesTags: ["Shop"],
+  }),
+  addShop: builder.mutation({
+    query: (shopData: any) => ({
+      url: "/shop",
+      method: "POST",
+      data: shopData,
+      isSeller: true,
+    }),
+    invalidatesTags: ["Shop"],
+  }),
+  updateShop: builder.mutation({
+    query: (shopData: any) => ({
+      url: "/shop",
+      method: "PUT",
+      data: shopData,
+      isSeller: true,
+    }),
+    invalidatesTags: ["Shop"],
+  }),
+  getShopCategories: builder.query({
+    query: (shopId: string) => ({
+      url: `/shops/${shopId}/categories`,
+      method: "GET",
+    }),
+    providesTags: (result: unknown, error: unknown, shopId: string) => [
+      { type: "ShopCategories", id: shopId },
+    ],
+  }),
+});


### PR DESCRIPTION
Implement shop categories endpoint in the backend, including service logic to fetch categories by shop ID. Integrate the endpoint with the frontend by adding the necessary API slice, redux store configuration, and updating the ShopDetails page to display the categories dynamically. This enables users to view and filter products by shop-specific categories.