### PR TITLE
feat(shop): add endpoint to fetch all shops with pagination and filte…

### DIFF
--- a/backend/controllers/shop.controller.ts
+++ b/backend/controllers/shop.controller.ts
@@ -11,6 +11,39 @@ class ShopController {
     this.shopService = shopService;
   }
 
+  async getAllShops(req: Request, res: Response, next: NextFunction) {
+    try {
+      const page = parseInt(req.query.page as string) || 1;
+      const limit = parseInt(req.query.limit as string) || 10;
+      const search = (req.query.search as string) || "";
+      const isAll = req.query.all === "true";
+      const filter = search ? { name: { $regex: search, $options: "i" } } : {};
+
+      if (isAll) {
+        const results = await this.shopService.getAllShops();
+        ResponseModel.ok(
+          "Shops fetched successfully.",
+          results.shops
+        ).send(res);
+        return;
+      }
+
+      const result = await this.shopService.getAllShops({
+        page,
+        limit,
+        filter,
+      });
+
+      ResponseModel.ok(
+        "Shops fetched successfully.",
+        result.shops,
+        result.pagination
+      ).send(res);
+    } catch (err) {
+      next(err);
+    }
+  }
+
   async getShopBySellerId(req: Request, res: Response, next: NextFunction) {
     try {
       const shopId = req.params.shopId;

--- a/backend/routes/shop.routes.ts
+++ b/backend/routes/shop.routes.ts
@@ -6,6 +6,8 @@ const shopController = new ShopController(shopService);
 
 const router = Router();
 
+router.get("/", shopController.getAllShops.bind(shopController));
+
 router.get(
   "/:shopId/categories",
   shopController.getShopCategories.bind(shopController)

--- a/backend/services/shop.service.ts
+++ b/backend/services/shop.service.ts
@@ -5,6 +5,39 @@ import { sanitizeDocument } from "@/utils/mongoose.util";
 import { NotFoundError } from "@/errors";
 
 class ShopService {
+  async getAllShops(
+    options: {
+      page?: number;
+      limit?: number;
+      filter?: Record<string, any>;
+    } = {}
+  ) {
+    const { page, limit, filter = {} } = options;
+    if (!page || !limit) {
+      const shops = await ShopModel.find(filter).sort({
+        createdAt: -1,
+      });
+      return { shops: shops.map((shop) => sanitizeDocument(shop)) };
+    }
+
+    const totalItems = await ShopModel.countDocuments(filter);
+    const totalPages = Math.ceil(totalItems / limit);
+    const shops = await ShopModel.find(filter)
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * limit)
+      .limit(limit);
+
+    return {
+      shops: shops.map((shop) => sanitizeDocument(shop)),
+      pagination: {
+        page,
+        limit,
+        totalItems,
+        totalPages,
+      },
+    };
+  }
+
   async getShopBySellerId(sellerId: string) {
     const shop = await ShopModel.findOne({ seller: sellerId });
 

--- a/frontend/src/pages/ShopListPage.jsx
+++ b/frontend/src/pages/ShopListPage.jsx
@@ -1,17 +1,24 @@
 import { Link } from "react-router-dom";
+import { useLazyGetShopsQuery } from "../store/features/shopApi";
+import { useInfiniteQuery } from "@mern/hooks";
 
 const ShopListPage = () => {
-  const mockShops = [
-    { id: "a", name: "Luna Store" },
-    { id: "b", name: "Galaxy Handmade" },
-    { id: "c", name: "BookNest" },
-  ];
+  const [trigger] = useLazyGetShopsQuery();
+
+  const {
+    data: shops,
+    hasMore,
+    ref: loaderRef,
+  } = useInfiniteQuery({
+    trigger,
+    limit: 10,
+  });
 
   return (
     <div className="w-[85%] mx-auto py-12">
       <h1 className="text-2xl font-bold mb-6">Popular Shops</h1>
-      <div className="grid grid-cols-2 sm:grid-cols-1 gap-6">
-        {mockShops.map((shop) => (
+      <div className="grid grid-cols-4 md-lg:grid-cols-2 sm:grid-cols-1 gap-6">
+        {shops.map((shop) => (
           <Link
             key={shop.id}
             to={`/shops/${shop.id}`}
@@ -21,6 +28,8 @@ const ShopListPage = () => {
           </Link>
         ))}
       </div>
+
+      {hasMore && <div ref={loaderRef}>Loading more...</div>}
     </div>
   );
 };

--- a/frontend/src/store/features/shopApi.js
+++ b/frontend/src/store/features/shopApi.js
@@ -10,4 +10,8 @@ export const shopApi = createApi({
   endpoints: shopEndpoints,
 });
 
-export const { useGetShopCategoriesQuery, useGetShopPriceRangeQuery } = shopApi;
+export const {
+  useGetShopCategoriesQuery,
+  useGetShopPriceRangeQuery,
+  useLazyGetShopsQuery,
+} = shopApi;

--- a/packages/apis/src/shopEndpoints.ts
+++ b/packages/apis/src/shopEndpoints.ts
@@ -1,4 +1,21 @@
 export const shopEndpoints = (builder: any) => ({
+  getShops: builder.query({
+    query: ({ page = 0, limit = 5, search = "", all = false } = {}) => {
+      if (all) {
+        return {
+          url: "/shops",
+          method: "GET",
+          params: { all: true, search },
+        };
+      }
+      return {
+        url: "/shops",
+        method: "GET",
+        params: { page, limit, search },
+      };
+    },
+    providesTags: ["Shop"],
+  }),
   getShopForCurrentSeller: builder.query({
     query: () => ({
       url: "/shop",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -8,11 +8,14 @@
     "start": "tsc --watch",
     "start:debug": "tsc --watch"
   },
-  "devDependencies": { 
+  "devDependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0"
+  },
+  "dependencies": {
+    "react-intersection-observer": "^9.16.0"
   }
 }

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./usePagination";
 export * from "./useDebouncedSearch";
-export * from './usePaginationSearch'
+export * from "./usePaginationSearch";
+export * from "./useInfiniteQuery";

--- a/packages/hooks/src/useInfiniteQuery.ts
+++ b/packages/hooks/src/useInfiniteQuery.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from "react";
+import { useInView } from "react-intersection-observer";
+
+type Params = {
+  page?: number;
+  limit?: number;
+  search?: string;
+  isAll?: boolean;
+};
+
+type InfiniteQueryOptions<T> = {
+  limit?: number;
+  initialPage?: number;
+  trigger: (params: Params) => Promise<{ data: { data: T[] } }>;
+};
+
+export const useInfiniteQuery = <T>({
+  limit = 10,
+  initialPage = 1,
+  trigger,
+}: InfiniteQueryOptions<T>) => {
+  const [data, setData] = useState<T[]>([]);
+  const [page, setPage] = useState(initialPage);
+  const [hasMore, setHasMore] = useState(true);
+  const { ref, inView } = useInView();
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || !inView) return;
+
+    const res = await trigger({ page, limit });
+    const fetched = res.data.data ?? [];
+
+    setData((prev) => [...prev, ...fetched]);
+    setHasMore(fetched.length === limit);
+    setPage((prev) => prev + 1);
+  }, [hasMore, inView, page, limit, trigger]);
+
+  useEffect(() => {
+    if (inView) loadMore();
+  }, [loadMore, inView]);  
+
+  return { data, hasMore, ref };
+};


### PR DESCRIPTION
resolves #83 
resolves #84 
resolves #85 

feat(shop): add endpoint to fetch all shops with pagination and filtering

This commit introduces a new endpoint `/` in the shop routes to fetch all shops. The `getAllShops` method in the service layer supports pagination and filtering, while the controller handles query parameters and sends the appropriate response. This feature enhances the shop management capabilities by allowing users to retrieve shops with customizable options.