### PR TITLE
feat(hooks): add useInfiniteQuery hook for paginated data fetching

### DIFF
--- a/frontend/src/pages/ShopListPage.jsx
+++ b/frontend/src/pages/ShopListPage.jsx
@@ -1,17 +1,24 @@
 import { Link } from "react-router-dom";
+import { useLazyGetShopsQuery } from "../store/features/shopApi";
+import { useInfiniteQuery } from "@mern/hooks";
 
 const ShopListPage = () => {
-  const mockShops = [
-    { id: "a", name: "Luna Store" },
-    { id: "b", name: "Galaxy Handmade" },
-    { id: "c", name: "BookNest" },
-  ];
+  const [trigger] = useLazyGetShopsQuery();
+
+  const {
+    data: shops,
+    hasMore,
+    ref: loaderRef,
+  } = useInfiniteQuery({
+    trigger,
+    limit: 10,
+  });
 
   return (
     <div className="w-[85%] mx-auto py-12">
       <h1 className="text-2xl font-bold mb-6">Popular Shops</h1>
-      <div className="grid grid-cols-2 sm:grid-cols-1 gap-6">
-        {mockShops.map((shop) => (
+      <div className="grid grid-cols-4 md-lg:grid-cols-2 sm:grid-cols-1 gap-6">
+        {shops.map((shop) => (
           <Link
             key={shop.id}
             to={`/shops/${shop.id}`}
@@ -21,6 +28,8 @@ const ShopListPage = () => {
           </Link>
         ))}
       </div>
+
+      {hasMore && <div ref={loaderRef}>Loading more...</div>}
     </div>
   );
 };

--- a/frontend/src/store/features/shopApi.js
+++ b/frontend/src/store/features/shopApi.js
@@ -10,4 +10,8 @@ export const shopApi = createApi({
   endpoints: shopEndpoints,
 });
 
-export const { useGetShopCategoriesQuery, useGetShopPriceRangeQuery } = shopApi;
+export const {
+  useGetShopCategoriesQuery,
+  useGetShopPriceRangeQuery,
+  useLazyGetShopsQuery,
+} = shopApi;

--- a/packages/apis/src/shopEndpoints.ts
+++ b/packages/apis/src/shopEndpoints.ts
@@ -1,4 +1,21 @@
 export const shopEndpoints = (builder: any) => ({
+  getShops: builder.query({
+    query: ({ page = 0, limit = 5, search = "", all = false } = {}) => {
+      if (all) {
+        return {
+          url: "/shops",
+          method: "GET",
+          params: { all: true, search },
+        };
+      }
+      return {
+        url: "/shops",
+        method: "GET",
+        params: { page, limit, search },
+      };
+    },
+    providesTags: ["Shop"],
+  }),
   getShopForCurrentSeller: builder.query({
     query: () => ({
       url: "/shop",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -8,11 +8,14 @@
     "start": "tsc --watch",
     "start:debug": "tsc --watch"
   },
-  "devDependencies": { 
+  "devDependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0"
+  },
+  "dependencies": {
+    "react-intersection-observer": "^9.16.0"
   }
 }

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./usePagination";
 export * from "./useDebouncedSearch";
-export * from './usePaginationSearch'
+export * from "./usePaginationSearch";
+export * from "./useInfiniteQuery";

--- a/packages/hooks/src/useInfiniteQuery.ts
+++ b/packages/hooks/src/useInfiniteQuery.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from "react";
+import { useInView } from "react-intersection-observer";
+
+type Params = {
+  page?: number;
+  limit?: number;
+  search?: string;
+  isAll?: boolean;
+};
+
+type InfiniteQueryOptions<T> = {
+  limit?: number;
+  initialPage?: number;
+  trigger: (params: Params) => Promise<{ data: { data: T[] } }>;
+};
+
+export const useInfiniteQuery = <T>({
+  limit = 10,
+  initialPage = 1,
+  trigger,
+}: InfiniteQueryOptions<T>) => {
+  const [data, setData] = useState<T[]>([]);
+  const [page, setPage] = useState(initialPage);
+  const [hasMore, setHasMore] = useState(true);
+  const { ref, inView } = useInView();
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || !inView) return;
+
+    const res = await trigger({ page, limit });
+    const fetched = res.data.data ?? [];
+
+    setData((prev) => [...prev, ...fetched]);
+    setHasMore(fetched.length === limit);
+    setPage((prev) => prev + 1);
+  }, [hasMore, inView, page, limit, trigger]);
+
+  useEffect(() => {
+    if (inView) loadMore();
+  }, [loadMore, inView]);  
+
+  return { data, hasMore, ref };
+};


### PR DESCRIPTION
The useInfiniteQuery hook is introduced to handle infinite scrolling functionality. It integrates with react-intersection-observer to trigger data fetching when the user scrolls to the bottom of the list. This hook is used in the ShopListPage to replace mock data with real data fetched from the API, improving the user experience by dynamically loading more shops as needed.