### PR TITLE
build: add chokidar and watch scripts for backend development

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "@types/mongoose": "^5.11.97",
     "@types/multer": "^1.4.12",
     "@types/node": "^22.14.0",
+    "chokidar": "^4.0.3",
     "ts-node-dev": "^2.0.0",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.8.2"
@@ -40,7 +41,9 @@
   },
   "scripts": {
     "start": "ts-node-dev --respawn --transpile-only -r tsconfig-paths/register server.ts",
-    "start:debug": "ts-node-dev --respawn --transpile-only --inspect=9229 -r tsconfig-paths/register server.ts",
+    "start:debug": "ts-node ./scripts/watch-and-start.ts --debug",
+    "watch": "ts-node ./scripts/watch-and-start.ts",
+    "watch:debug": "ts-node ./scripts/watch-and-start.ts --debug",
     "build": "tsc"
   }
 }

--- a/backend/scripts/watch-and-start.ts
+++ b/backend/scripts/watch-and-start.ts
@@ -1,0 +1,62 @@
+import chokidar from "chokidar";
+import { spawn } from "child_process";
+
+const mode = process.argv.includes("--debug") ? "start:debug" : "start";
+
+let server: ReturnType<typeof spawn> | null = null;
+
+const start = () => {
+  const isDebug = process.argv.includes("--debug");
+  const args = isDebug
+    ? [
+        "ts-node-dev",
+        "--respawn",
+        "--transpile-only",
+        "--inspect=9229",
+        "-r",
+        "tsconfig-paths/register",
+        "server.ts",
+      ]
+    : [
+        "ts-node-dev",
+        "--respawn",
+        "--transpile-only",
+        "-r",
+        "tsconfig-paths/register",
+        "server.ts",
+      ];
+
+  console.info(
+    `%c[watcher]: 🟢 Starting backend dev server (${mode})...\n`,
+    "color: green"
+  );
+  server = spawn("yarn", args, {
+    stdio: "inherit",
+    shell: true,
+    cwd: process.cwd(),
+  });
+};
+
+const restart = () => {
+  if (server) {
+    console.info(
+      `%c[watcher]: 🔴 Restarting backend dev server (${mode})...\n`,
+      "color: red"
+    );
+    server?.kill();
+  }
+  start();
+};
+
+const watcher = chokidar.watch("./**/*.ts", {
+  ignored: ["./node_modules/**", "**/dist/**"],
+  persistent: true,
+  ignoreInitial: true,
+});
+
+watcher.on("all", (event, path) => {
+  console.info(`%c[watcher]: ${event} ${path}\n`, "color: blue");
+  restart();
+});
+
+start();


### PR DESCRIPTION
Introduce chokidar dependency and create a new watch-and-start.ts script to enable file watching and automatic server restarts during development. This improves the development workflow by eliminating the need for manual server restarts when code changes are made.