### PR TITLE
closes #97

### DIFF
--- a/frontend/src/pages/ShopDetails.jsx
+++ b/frontend/src/pages/ShopDetails.jsx
@@ -4,7 +4,7 @@ import { Range } from "react-range";
 import { FaThList } from "react-icons/fa";
 import { cn } from "@mern/utils";
 import { Pagination } from "@mern/ui";
-import { usePagination } from "@mern/hooks";
+import { useDebouncedValue, usePagination } from "@mern/hooks";
 
 import Ratings from "../components/shared/Ratings";
 import ProductStack from "../components/features/products/ProductStack";
@@ -28,15 +28,19 @@ const Shops = () => {
   const [selectedRating, setSelectedRating] = useState(0);
   const [viewMode, setViewMode] = useState("grid");
   const [selectedCategories, setSelectedCategories] = useState([]);
+  const debouncedCategories = useDebouncedValue(selectedCategories, 800);
 
   const { currentPage, setCurrentPage, perPage } = usePagination();
 
   const { data: categories } = useGetShopCategoriesQuery(shopId);
   const { data: priceRange } = useGetShopPriceRangeQuery(shopId);
-  const { data: productList } = useGetProductsQuery({
-    page: currentPage,
-    category: selectedCategories,
-  });
+  const { data: productList } = useGetProductsQuery(
+    {
+      page: currentPage,
+      category: debouncedCategories,
+    },
+    { refetchOnMountOrArgChange: true }
+  );
 
   useEffect(() => {
     if (priceRange?.data) {

--- a/packages/hooks/src/useDebouncedValue.ts
+++ b/packages/hooks/src/useDebouncedValue.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { debounce } from "lodash";
+import { debounce, isEqual } from "lodash";
 
 export const useDebouncedValue = <T>(
   value: T,
@@ -14,7 +14,12 @@ export const useDebouncedValue = <T>(
 
   const debouncer = useMemo(() => {
     return debounce((val: T) => {
-      setDebouncedValue(val);
+      setDebouncedValue((prev) => {
+        const shouldUpdate =
+          !isEqual(prev, val) || (Array.isArray(val) && val.length === 0);
+
+        return shouldUpdate ? val : prev;
+      });
     }, delay);
   }, [delay]);
 


### PR DESCRIPTION
fix(hooks): prevent unnecessary updates in useDebouncedValue

Add isEqual check to avoid updating debounced value when the new value is equal to the previous one. This prevents unnecessary re-renders and API calls in the ShopDetails page when the selected categories haven't changed.