### PR TITLE
feat(product): add support for fetching products by shopId

### DIFF
--- a/backend/controllers/product.controller.ts
+++ b/backend/controllers/product.controller.ts
@@ -136,6 +136,51 @@ class ProductController {
     }
   }
 
+  async getProductsByShopId(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { shopId } = req.params;
+      const page = parseInt(req.query.page as string) || 1;
+      const limit = parseInt(req.query.limit as string) || 12;
+      const search = (req.query.search as string) || "";
+      const categories = (req.query.categories as string)
+        ? (req.query.categories as string).split(",")
+        : [];
+      const priceLow = req.query.priceLow ? parseInt(req.query.priceLow as string) : undefined;
+      const priceHigh = req.query.priceHigh? parseInt(req.query.priceHigh as string) : undefined;
+      const sortBy = req.query.sortBy as string ?? undefined;
+
+      const isAll = req.query.all === "true";
+
+      if (isAll) {
+        const results = await this.productService.getAllProducts();
+        ResponseModel.ok(
+          "Products fetched successfully.",
+          results.products
+        ).send(res);
+        return;
+      }
+
+      const result = await this.productService.getProductsByShopId({
+        page,
+        limit,
+        search,
+        categories,
+        priceLow,
+        priceHigh,
+        sortBy,
+        shopId
+      });
+
+      ResponseModel.ok(
+        "Products fetched successfully.",
+        result.products,
+        result.pagination
+      ).send(res);
+    } catch (err) {
+      return next(err);
+    }
+  }
+
   async getProductById(req: Request, res: Response, next: NextFunction) {
     try {
       const { productId } = req.params;

--- a/backend/routes/product.routes.ts
+++ b/backend/routes/product.routes.ts
@@ -29,6 +29,10 @@ router.get(
 );
 router.use("/products", featuredProductRoutes)
 router.get(
+  "/products/shop/:shopId",
+  productController.getProductsByShopId.bind(productController)
+)
+router.get(
   "/products/:productId",
   productController.getProductById.bind(productController)
 );

--- a/frontend/src/pages/ShopDetails.jsx
+++ b/frontend/src/pages/ShopDetails.jsx
@@ -16,7 +16,7 @@ import {
   useGetShopCategoriesQuery,
   useGetShopPriceRangeQuery,
 } from "../store/features/shopApi";
-import { useGetProductsQuery } from "../store/features/productApi";
+import { useGetProductsByShopIdQuery } from "../store/features/productApi";
 
 const viewModes = ["grid", "list"];
 
@@ -45,13 +45,14 @@ const Shops = () => {
 
   const { data: categories } = useGetShopCategoriesQuery(shopId);
   const { data: priceRange } = useGetShopPriceRangeQuery(shopId);
-  const { data: productList } = useGetProductsQuery(
+  const { data: productList } = useGetProductsByShopIdQuery(
     {
       page: currentPage,
       categories: debouncedCategories,
       priceRange: debouncedPriceRange,
       sortBy,
       rating: selectedRating,
+      shopId,
     },
     { refetchOnMountOrArgChange: true }
   );

--- a/frontend/src/store/features/productApi.js
+++ b/frontend/src/store/features/productApi.js
@@ -10,4 +10,4 @@ export const productApi = createApi({
   endpoints: productEndpoints,
 });
 
-export const { useGetProductsQuery } = productApi;
+export const { useGetProductsQuery, useGetProductsByShopIdQuery } = productApi;

--- a/gh-label-updater.sh
+++ b/gh-label-updater.sh
@@ -1,0 +1,16 @@
+#!/bin/zsh
+
+set +o histexpand
+
+issue_labels=(
+  117 "backend,frontend,storefront,feature"
+)
+        
+for ((i = 1; i <= ${#issue_labels[@]}; i += 2)); do
+  issue_id="${issue_labels[i]}"
+  labels="${issue_labels[i+1]}"∏
+  echo "🏷️  Updating labels for issue #$issue_id -> \"$labels\"..."
+  gh issue edit "$issue_id" --add-label "$labels"
+done
+
+echo "✅ All labels applied!"

--- a/packages/apis/src/productEndpoints.ts
+++ b/packages/apis/src/productEndpoints.ts
@@ -1,8 +1,56 @@
 import _ from "lodash";
 
-type PriceRange = {
+export type PriceRange = {
   minPrice?: number;
   maxPrice?: number;
+};
+
+export type ProductQueryParams = {
+  page?: number;
+  limit?: number;
+  search?: string;
+  categories?: string[];
+  priceRange?: PriceRange;
+  sortBy?: string;
+  rating?: number;
+  all?: boolean;
+};
+
+const buildProductParams = ({
+  page = 1,
+  limit = 12,
+  search = "",
+  categories = [],
+  priceRange = {},
+  sortBy = "",
+  rating = 0,
+  all = false,
+}: ProductQueryParams): Record<string, any> => {
+  if (all) return { all: true, sortBy };
+
+  const params: Record<string, any> = { page, limit, search };
+
+  if (categories.length > 0) {
+    params.categories = categories.join(",");
+  }
+
+  if (_.isNumber(priceRange.minPrice)) {
+    params.priceLow = priceRange.minPrice;
+  }
+
+  if (_.isNumber(priceRange.maxPrice)) {
+    params.priceHigh = priceRange.maxPrice;
+  }
+
+  if (sortBy) {
+    params.sortBy = sortBy;
+  }
+
+  if (rating > 0) {
+    params.rating = rating;
+  }
+
+  return params;
 };
 
 export const productEndpoints = (builder: any) => ({
@@ -16,52 +64,22 @@ export const productEndpoints = (builder: any) => ({
     ],
   }),
   getProducts: builder.query({
+    query: (options: ProductQueryParams) => ({
+      url: "/products",
+      method: "GET",
+      params: buildProductParams(options),
+    }),
+    providesTags: ["Product"],
+  }),
+  getProductsByShopId: builder.query({
     query: ({
-      page = 1,
-      limit = 12,
-      search = "",
-      categories = [],
-      priceRange = {} as PriceRange,
-      sortBy = "",
-      rating = 0,
-      all = false,
-    } = {}) => {
-      if (all) {
-        return {
-          url: "/products",
-          method: "GET",
-          params: { all: true, sortBy },
-        };
-      }
-
-      const params: Record<string, any> = { page, limit, search };
-
-      if (categories.length > 0) {
-        params.categories = categories.join(",");
-      }
-
-      if (_.isNumber(priceRange.minPrice)) {
-        params.priceLow = priceRange.minPrice;
-      }
-
-      if (_.isNumber(priceRange.maxPrice)) {
-        params.priceHigh = priceRange.maxPrice;
-      }
-
-      if (sortBy) {
-        params.sortBy = sortBy;
-      }
-
-      if (rating > 0) {
-        params.rating = rating;
-      }
-
-      return {
-        url: "/products",
-        method: "GET",
-        params,
-      };
-    },
+      shopId = "",
+      ...options
+    }: ProductQueryParams & { shopId?: string }) => ({
+      url: `/products/shop/${shopId}`,
+      method: "GET",
+      params: buildProductParams(options),
+    }),
     providesTags: ["Product"],
   }),
   addProduct: builder.mutation({


### PR DESCRIPTION
Introduce a new feature to fetch products by shopId across the backend, frontend, and API layers. This includes adding a new endpoint, controller method, service logic, and frontend query hook to support filtering products based on the shop they belong to.